### PR TITLE
[ADD][ezyfox-concurrent][add EzyConcurrentHandler, add concurrent map lock provider]

### DIFF
--- a/ezyfox-concurrent/src/main/java/com/tvd12/ezyfox/concurrent/EzyConcurrentHandler.java
+++ b/ezyfox-concurrent/src/main/java/com/tvd12/ezyfox/concurrent/EzyConcurrentHandler.java
@@ -1,0 +1,34 @@
+package com.tvd12.ezyfox.concurrent;
+
+import java.util.concurrent.locks.Lock;
+import java.util.function.Supplier;
+
+public class EzyConcurrentHandler {
+
+    private EzyConcurrentMapLockProxyProvider lockProvider;
+
+    public EzyConcurrentHandler(EzyConcurrentMapLockProxyProvider lockProvider) {
+        this.lockProvider = lockProvider;
+    }
+
+    public <K> void doInLock(K key, Runnable task) throws InterruptedException {
+        Lock lock = lockProvider.provideLock(key);
+        lock.lockInterruptibly();
+        try {
+            task.run();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public <K, R> R getInLock(K key, Supplier<R> task) throws InterruptedException {
+        Lock lock = lockProvider.provideLock(key);
+        lock.lockInterruptibly();
+        try {
+            return task.get();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+}

--- a/ezyfox-concurrent/src/main/java/com/tvd12/ezyfox/concurrent/EzyConcurrentHashMapLockProxyProvider.java
+++ b/ezyfox-concurrent/src/main/java/com/tvd12/ezyfox/concurrent/EzyConcurrentHashMapLockProxyProvider.java
@@ -1,0 +1,13 @@
+package com.tvd12.ezyfox.concurrent;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class EzyConcurrentHashMapLockProxyProvider extends EzyConcurrentMapLockProxyProvider {
+
+    @Override
+    protected ConcurrentMap<Object, EzyLockProxy> newLockMap() {
+        return new ConcurrentHashMap<>();
+    }
+
+}

--- a/ezyfox-concurrent/src/main/java/com/tvd12/ezyfox/concurrent/EzyConcurrentMapLockProxyProvider.java
+++ b/ezyfox-concurrent/src/main/java/com/tvd12/ezyfox/concurrent/EzyConcurrentMapLockProxyProvider.java
@@ -1,0 +1,54 @@
+package com.tvd12.ezyfox.concurrent;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.Lock;
+
+public abstract class EzyConcurrentMapLockProxyProvider implements EzyMapLockProvider {
+
+    protected final ConcurrentMap<Object, EzyLockProxy> locks;
+
+    public EzyConcurrentMapLockProxyProvider() {
+        this.locks = newLockMap();
+    }
+
+    protected abstract ConcurrentMap<Object, EzyLockProxy> newLockMap();
+
+    @Override
+    public Lock provideLock(Object key) {
+        return locks.computeIfAbsent(key, k -> {
+            EzyLockProxy lock = new EzyLockProxy();
+            lock.retain();
+            return lock;
+        });
+    }
+
+    @Override
+    public Lock getLock(Object key) {
+        return locks.get(key);
+    }
+
+    @Override
+    public void removeLock(Object key) {
+        final EzyLockProxy lock = locks.get(key);
+        if (Objects.nonNull(lock)) {
+            synchronized (lock) {
+                lock.release();
+                if (lock.isReleasable()) {
+                    locks.remove(key);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void removeLocks(Set<?> keys) {
+        keys.forEach(this::removeLock);
+    }
+
+    @Override
+    public int size() {
+        return locks.size();
+    }
+}

--- a/ezyfox-concurrent/src/test/java/com/tvd12/ezyfox/testing/concurrent/EzyConcurrentHandlerTest.java
+++ b/ezyfox-concurrent/src/test/java/com/tvd12/ezyfox/testing/concurrent/EzyConcurrentHandlerTest.java
@@ -1,0 +1,90 @@
+package com.tvd12.ezyfox.testing.concurrent;
+
+import com.tvd12.ezyfox.concurrent.EzyConcurrentHandler;
+import com.tvd12.ezyfox.concurrent.EzyConcurrentHashMapLockProxyProvider;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+public class EzyConcurrentHandlerTest {
+
+    @Test
+    public void test_cacheMissStorm1() throws InterruptedException {
+        Map<String, Object> foolCache = new HashMap<>();
+        AtomicInteger cachedHitCounter = new AtomicInteger(0);
+
+        EzyConcurrentHashMapLockProxyProvider providerBean = new EzyConcurrentHashMapLockProxyProvider();
+        EzyConcurrentHandler concurrentHandler = new EzyConcurrentHandler(providerBean);
+        String userID = "1";
+        int threadNum = 1000;
+        int coreSize = 20;
+        ExecutorService executorService = Executors.newFixedThreadPool(coreSize);
+        final CountDownLatch waiter = new CountDownLatch(threadNum);
+
+        Supplier<Runnable> task = () -> {
+            return () -> {
+                try {
+                    concurrentHandler.doInLock(userID, () -> {
+                        if (!foolCache.containsKey(userID)) {
+                            foolCache.put(userID, new Object());
+                            cachedHitCounter.incrementAndGet();
+                        }
+                        waiter.countDown();
+                    });
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            };
+        };
+        IntStream.range(0, threadNum).forEach(item -> {
+            executorService.execute(task.get());
+        });
+        waiter.await();
+        assert cachedHitCounter.get() == 1;
+    }
+
+    @Test
+    public void test_cacheMissStorm2() throws InterruptedException {
+        Map<String, Object> foolCache = new ConcurrentHashMap<>();
+        AtomicInteger cachedHitCounter = new AtomicInteger(0);
+
+        EzyConcurrentHashMapLockProxyProvider providerBean = new EzyConcurrentHashMapLockProxyProvider();
+        EzyConcurrentHandler concurrentHandler = new EzyConcurrentHandler(providerBean);
+        String userID = "1";
+        int threadNum = 1000;
+        int coreSize = 20;
+        ExecutorService executorService = Executors.newFixedThreadPool(coreSize);
+        CountDownLatch waiter = new CountDownLatch(threadNum);
+
+        Supplier<Runnable> task = () -> {
+            return () -> {
+                try {
+                    concurrentHandler.getInLock(userID, () -> {
+                        if (!foolCache.containsKey(userID)) {
+                            foolCache.put(userID, new Object());
+                            cachedHitCounter.incrementAndGet();
+                        }
+                        waiter.countDown();
+                        return 1;
+                    });
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            };
+        };
+        IntStream.range(0, threadNum).forEach(item -> {
+            executorService.execute(task.get());
+        });
+        waiter.await();
+        assert cachedHitCounter.get() == 1;
+    }
+
+}

--- a/ezyfox-concurrent/src/test/java/com/tvd12/ezyfox/testing/concurrent/EzyConcurrentHashMapLockProxyProviderTest.java
+++ b/ezyfox-concurrent/src/test/java/com/tvd12/ezyfox/testing/concurrent/EzyConcurrentHashMapLockProxyProviderTest.java
@@ -1,0 +1,34 @@
+package com.tvd12.ezyfox.testing.concurrent;
+
+import com.tvd12.ezyfox.concurrent.EzyConcurrentHashMapLockProxyProvider;
+import com.tvd12.ezyfox.concurrent.EzyConcurrentMapLockProxyProvider;
+import org.testng.annotations.Test;
+
+import java.util.Objects;
+import java.util.concurrent.locks.Lock;
+import java.util.function.Supplier;
+
+public class EzyConcurrentHashMapLockProxyProviderTest {
+
+    @Test
+    public void test() throws InterruptedException {
+        final EzyConcurrentMapLockProxyProvider lockProvider = new EzyConcurrentHashMapLockProxyProvider();
+        final String key = "accountID";
+        final Supplier<Runnable> task = () -> {
+          return () -> {
+              Lock lock = lockProvider.provideLock(key);
+              assert lockProvider.getLock(key).equals(lock);
+              lockProvider.removeLock(key);
+          };
+        };
+
+        Thread t1 = new Thread(task.get());
+        Thread t2 = new Thread(task.get());
+        t1.start();
+        t2.start();
+        t1.join();
+        t2.join();
+        assert Objects.isNull(lockProvider.getLock(key));
+    }
+
+}


### PR DESCRIPTION
Hi anh,
Vì ở `EzyConcurrentHandler` có dùng `EzyConcurrentMapLockProxyProvider`.
Nên ở PR này em không thể tách nhỏ thêm được nữa ạ.
